### PR TITLE
only implement fail for old ghc version

### DIFF
--- a/src/Ldap/Asn1/FromAsn1.hs
+++ b/src/Ldap/Asn1/FromAsn1.hs
@@ -412,7 +412,9 @@ instance Monad (Parser s) where
   return x = Parser (\s -> return (s, x))
   Parser mx >>= k =
     Parser (mx >=> \(s', x) -> unParser (k x) s')
+#if !__GLASGOW_HASKELL__ >= 86
   fail _ = empty
+#endif
 
 instance MonadPlus (Parser s) where
   mzero = Parser (\_ -> mzero)


### PR DESCRIPTION
ldap-client doesn't compile on 8.8.2 because fail is not a (visible) member of Monad anymore.
I fixed this by excluding fail, which is already included in the MonadFail instance below.