### PR TITLE
Change dependency from "connection" to "crypton-connection"

### DIFF
--- a/ldap-client.cabal
+++ b/ldap-client.cabal
@@ -51,16 +51,16 @@ library
     Ldap.Client.Modify
     Ldap.Client.Search
   build-depends:
-      asn1-encoding >= 0.9
-    , asn1-types    >= 0.3
+      asn1-encoding         >= 0.9
+    , asn1-types            >= 0.3
     , async
-    , base          >= 4.6 && < 5
+    , base                  >= 4.6 && < 5
     , bytestring
-    , connection    >= 0.2
+    , crypton-connection    >= 0.2
     , containers
     , fail
-    , network       >= 2.6
-    , semigroups    >= 0.16
+    , network               >= 2.6
+    , semigroups            >= 0.16
     , stm
     , text
 


### PR DESCRIPTION
Background: "connection" has been archived due to the switch in the Haskell crypto ecosystem to the "crypton" base. Renaming the dependency fixes the library.

I have run `cabal build`, even with a new ghc (9.4) and it compiles just fine.

Would you merge this and release a new version so we have something working in hackage again? :)